### PR TITLE
Homework 6

### DIFF
--- a/api-examples/comments.http
+++ b/api-examples/comments.http
@@ -3,3 +3,14 @@
 GET http://example.front.ylab.io/api/v1/comments?fields=items(_id,text,dateCreate,author(profile(name)),parent(_id,_type),isDeleted),count&limit=*&search[parent]=65817bed5c295a2ff2fcd189
 
 # Остальные методы в http://example.front.ylab.io/api/v1/docs/ (http://localhost:8010/api/v1/docs/)
+
+###
+# Создание коммента
+POST http://example.front.ylab.io/api/v1/comments
+Content-Type: application/json
+X-Token: ed9b341d85860b91420b216594a433c1e3d564cd7246e714ee02b3ec395a6ce5
+
+{
+  "text": "Первый коммент!",
+  "parent": {"_id":  "65817bed5c295a2ff2fcd189", "_type":  "article"}
+}

--- a/src/app/article/index.js
+++ b/src/app/article/index.js
@@ -1,18 +1,20 @@
-import {memo, useCallback, useMemo} from 'react';
-import {useParams} from 'react-router-dom';
-import useStore from '../../hooks/use-store';
-import useTranslate from '../../hooks/use-translate';
-import useInit from '../../hooks/use-init';
-import PageLayout from '../../components/page-layout';
-import Head from '../../components/head';
-import Navigation from '../../containers/navigation';
-import Spinner from '../../components/spinner';
-import ArticleCard from '../../components/article-card';
-import LocaleSelect from '../../containers/locale-select';
-import TopHead from '../../containers/top-head';
-import {useDispatch, useSelector} from 'react-redux';
-import shallowequal from 'shallowequal';
-import articleActions from '../../store-redux/article/actions';
+import {memo, useCallback} from "react";
+import {useParams} from "react-router-dom";
+import useStore from "../../hooks/use-store";
+import useTranslate from "../../hooks/use-translate";
+import useInit from "../../hooks/use-init";
+import PageLayout from "../../components/page-layout";
+import Head from "../../components/head";
+import Navigation from "../../containers/navigation";
+import Spinner from "../../components/spinner";
+import ArticleCard from "../../components/article-card";
+import LocaleSelect from "../../containers/locale-select";
+import TopHead from "../../containers/top-head";
+import {useDispatch, useSelector} from "react-redux";
+import shallowequal from "shallowequal";
+import articleActions from "../../store-redux/article/actions";
+import commentsActions from "../../store-redux/comments/actions";
+import CommentsList from "../../containers/comments-list";
 
 function Article() {
   const store = useStore();
@@ -22,9 +24,10 @@ function Article() {
 
   const params = useParams();
 
-  useInit(() => {
+  useInit(async () => {
     //store.actions.article.load(params.id);
     dispatch(articleActions.load(params.id));
+    dispatch(commentsActions.load(params.id));
   }, [params.id]);
 
   const select = useSelector(state => ({
@@ -37,7 +40,7 @@ function Article() {
   const callbacks = {
     // Добавление в корзину
     addToBasket: useCallback(_id => store.actions.basket.addToBasket(_id), [store]),
-  }
+  };
 
   return (
     <PageLayout>
@@ -47,8 +50,11 @@ function Article() {
       </Head>
       <Navigation/>
       <Spinner active={select.waiting}>
-        <ArticleCard article={select.article} onAdd={callbacks.addToBasket} t={t}/>
+        <ArticleCard article={select.article}
+                     onAdd={callbacks.addToBasket}
+                     t={t}/>
       </Spinner>
+      <CommentsList articleId={params.id}/>
     </PageLayout>
   );
 }

--- a/src/app/article/index.js
+++ b/src/app/article/index.js
@@ -22,20 +22,21 @@ function Article() {
   const dispatch = useDispatch();
   // Параметры из пути /articles/:id
 
+  const {t, lang} = useTranslate();
+
   const params = useParams();
 
   useInit(async () => {
     //store.actions.article.load(params.id);
     dispatch(articleActions.load(params.id));
     dispatch(commentsActions.load(params.id));
-  }, [params.id]);
+  }, [params.id, lang]);
 
   const select = useSelector(state => ({
     article: state.article.data,
     waiting: state.article.waiting,
   }), shallowequal); // Нужно указать функцию для сравнения свойства объекта, так как хуком вернули объект
 
-  const {t} = useTranslate();
 
   const callbacks = {
     // Добавление в корзину

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -14,14 +14,16 @@ function Main() {
 
   const store = useStore();
 
+  const {lang, t} = useTranslate();
+
   useInit(async () => {
     await Promise.all([
       store.actions.catalog.initParams(),
       store.actions.categories.load()
     ]);
-  }, [], true);
+  }, [lang], true);
 
-  const {t} = useTranslate();
+
 
   return (
     <PageLayout>

--- a/src/app/profile/index.js
+++ b/src/app/profile/index.js
@@ -15,17 +15,18 @@ import ProfileCard from '../../components/profile-card';
 
 function Profile() {
   const store = useStore();
+  const {lang, t} = useTranslate();
 
   useInit(() => {
     store.actions.profile.load();
-  }, []);
+  }, [lang]);
 
   const select = useSelector(state => ({
     profile: state.profile.data,
     waiting: state.profile.waiting,
   }));
 
-  const {t} = useTranslate();
+
 
   return (
     <PageLayout>

--- a/src/components/article-comments/index.js
+++ b/src/components/article-comments/index.js
@@ -1,0 +1,18 @@
+import {cn as bem} from '@bem-react/classname';
+import './style.css';
+import PropTypes from "prop-types";
+
+function ArticleComments(props) {
+  const cn = bem('ArticleComments')
+  return (<div className={cn()}>
+    <p className={cn('title')}>{props.title}</p>
+    {props.children}
+  </div>)
+}
+
+ArticleComments.propTypes = {
+  children: PropTypes.node,
+  title: PropTypes.string,
+}
+
+export default ArticleComments

--- a/src/components/article-comments/style.css
+++ b/src/components/article-comments/style.css
@@ -1,0 +1,12 @@
+.ArticleComments {
+  padding: 25px 40px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.ArticleComments-title {
+  margin: 0;
+  padding: 0;
+  font-size: 24px;
+}

--- a/src/components/comment-fallback/index.js
+++ b/src/components/comment-fallback/index.js
@@ -1,12 +1,15 @@
-import {cn as bem} from '@bem-react/classname';
-import './style.css';
+import {cn as bem} from "@bem-react/classname";
+import "./style.css";
 import PropTypes from "prop-types";
 
 function CommentFallback(props) {
-  const cn = bem('CommentFallback');
+  const cn = bem("CommentFallback");
   return (<p className={cn()}>
-    <span className={cn('signin')} onClick={props.signInAction}>{props.loginLabel}</span>{props.text}{!!props.reset && <span className={cn('reset')} onClick={props.resetAction}>{props.reset}</span>}
-  </p>)
+    <span className={cn("signin")}
+          onClick={props.signInAction}>{props.loginLabel}</span>{props.text}{!!props.reset &&
+    <span className={cn("reset")}
+          onClick={props.resetAction}>{props.reset}</span>}
+  </p>);
 }
 
 CommentFallback.propTypes = {
@@ -15,11 +18,16 @@ CommentFallback.propTypes = {
   reset: PropTypes.string,
   resetAction: PropTypes.func,
   signInAction: PropTypes.func,
-}
+};
 
 CommentFallback.defaultProps = {
-  resetAction: () => {},
-  signInAction: () => {},
-}
+  loginLabel: "Войдите",
+  text: ", чтобы иметь возможность комментировать. ",
+  reset: "",
+  resetAction: () => {
+  },
+  signInAction: () => {
+  },
+};
 
 export default CommentFallback;

--- a/src/components/comment-fallback/index.js
+++ b/src/components/comment-fallback/index.js
@@ -1,0 +1,25 @@
+import {cn as bem} from '@bem-react/classname';
+import './style.css';
+import PropTypes from "prop-types";
+
+function CommentFallback(props) {
+  const cn = bem('CommentFallback');
+  return (<p className={cn()}>
+    <span className={cn('signin')} onClick={props.signInAction}>{props.loginLabel}</span>{props.text}{!!props.reset && <span className={cn('reset')} onClick={props.resetAction}>{props.reset}</span>}
+  </p>)
+}
+
+CommentFallback.propTypes = {
+  loginLabel: PropTypes.string,
+  text: PropTypes.string,
+  reset: PropTypes.string,
+  resetAction: PropTypes.func,
+  signInAction: PropTypes.func,
+}
+
+CommentFallback.defaultProps = {
+  resetAction: () => {},
+  signInAction: () => {},
+}
+
+export default CommentFallback;

--- a/src/components/comment-fallback/style.css
+++ b/src/components/comment-fallback/style.css
@@ -1,0 +1,18 @@
+.CommentFallback {
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+}
+
+.CommentFallback span {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.CommentFallback-signin {
+  color: #0087E9;
+}
+
+.CommentFallback-reset {
+  color: #666;
+}

--- a/src/components/comment-field/index.js
+++ b/src/components/comment-field/index.js
@@ -6,7 +6,12 @@ function CommentField(props) {
   const inputId = useId();
   const [text, setText] = useState('');
 
-  return (<form className="CommentField" onReset={props.onReset}>
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    props.onSubmit(text);
+  }
+
+  return (<form className="CommentField" onReset={props.onReset} onSubmit={handleSubmit}>
     <label htmlFor={inputId}>
       <strong>{props.label}</strong>
     </label>

--- a/src/components/comment-field/index.js
+++ b/src/components/comment-field/index.js
@@ -1,0 +1,43 @@
+import {useId, useState} from "react";
+import PropTypes from "prop-types";
+import './style.css'
+
+function CommentField(props) {
+  const inputId = useId();
+  const [text, setText] = useState('');
+
+  return (<form className="CommentField" onReset={props.onReset}>
+    <label htmlFor={inputId}>
+      <strong>{props.label}</strong>
+    </label>
+    <textarea name="comment"
+              id={inputId}
+              rows={4}
+              value={text}
+              onChange={e => setText(e.target.value)}
+              placeholder={props.placeholder}
+    ></textarea>
+    <div>
+      <button type="submit">{props.labelSend}</button>
+      {props.labelCancel && <button type="reset">{props.labelCancel}</button>}
+    </div>
+  </form>);
+}
+
+CommentField.propTypes = {
+  label: PropTypes.string,
+  labelSend: PropTypes.string,
+  labelCancel: PropTypes.string,
+  placeholder: PropTypes.string,
+  onSubmit: PropTypes.func,
+  onReset: PropTypes.func,
+}
+
+CommentField.defaultProps = {
+  labelCancel: '',
+  placeholder: 'Текст',
+  onSubmit: () => {},
+  onReset: () => {},
+}
+
+export default CommentField;

--- a/src/components/comment-field/index.js
+++ b/src/components/comment-field/index.js
@@ -39,6 +39,8 @@ CommentField.propTypes = {
 }
 
 CommentField.defaultProps = {
+  label: 'Новый комментарий',
+  labelSend: 'Отправить',
   labelCancel: '',
   placeholder: 'Текст',
   onSubmit: () => {},

--- a/src/components/comment-field/style.css
+++ b/src/components/comment-field/style.css
@@ -31,3 +31,8 @@
   display: inline-block;
   padding: 3px 8px;
 }
+
+.CommentField div {
+  display: flex;
+  gap: 10px;
+}

--- a/src/components/comment-field/style.css
+++ b/src/components/comment-field/style.css
@@ -1,0 +1,33 @@
+.CommentField {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.CommentField textarea {
+  font-family: Arial;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  color: #000;
+  font-size: 14px;
+}
+
+.CommentField textarea::placeholder {
+  font-family: Arial;
+  color: #000;
+  font-size: 14px;
+}
+
+.CommentField label {
+  font-size: 12px;
+}
+
+.CommentField button {
+  display: inline-block;
+  padding: 3px 8px;
+}

--- a/src/components/comment/comment.js
+++ b/src/components/comment/comment.js
@@ -21,7 +21,7 @@ function Comment(props) {
   return (<div className={cn()}>
     <p className={cn('title')}>
       <strong>{props.author.profile.name}</strong>
-      <span className={cn('date')}>{`${dataFromDate.date} ${dataFromDate.month} ${dataFromDate.year} в ${dataFromDate.hours}:${dataFromDate.minutes}`}</span>
+      <span className={cn('date')}>{`${dataFromDate.date} ${dataFromDate.month} ${dataFromDate.year} в ${dataFromDate.hours}:${dataFromDate.minutes > 10 ? dataFromDate.minutes : '0'+dataFromDate.minutes}`}</span>
     </p>
     <p className={cn('text')}>{props.text}</p>
     <p>

--- a/src/components/comment/comment.js
+++ b/src/components/comment/comment.js
@@ -1,0 +1,56 @@
+import PropTypes from "prop-types";
+import './style.css';
+import {cn as bem} from '@bem-react/classname';
+
+function Comment(props) {
+  const cn = bem('Comment');
+  const commentDate = new Date(props.dateCreate)
+
+  const dataFromDate = {
+    date: commentDate.getDate(),
+    month: commentDate.toLocaleString('default', { month: 'long' }),
+    year: commentDate.getFullYear(),
+    hours: commentDate.getHours(),
+    minutes: commentDate.getMinutes()
+  }
+
+  const clickHandle = () => {
+    props.answer(props._id);
+  }
+
+  return (<div className={cn()}>
+    <p className={cn('title')}>
+      <strong>{props.author.profile.name}</strong>
+      <span className={cn('date')}>{`${dataFromDate.date} ${dataFromDate.month} ${dataFromDate.year} в ${dataFromDate.hours}:${dataFromDate.minutes}`}</span>
+    </p>
+    <p className={cn('text')}>{props.text}</p>
+    <p>
+      <span className={cn('answer')} onClick={clickHandle}>Ответить</span>
+    </p>
+  </div>)
+}
+
+Comment.propTypes = {
+  _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  text: PropTypes.string,
+  dateCreate: PropTypes.string,
+  author: PropTypes.shape({
+    _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    profile: PropTypes.shape({
+      name: PropTypes.string,
+    })
+  }),
+  parent: PropTypes.shape({
+    _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    _type: PropTypes.string,
+  }),
+  isDeleted: PropTypes.bool,
+  offset: PropTypes.number,
+  answer: PropTypes.func,
+}
+
+Comment.defaultProps = {
+  answer: () => {},
+}
+
+export default Comment;

--- a/src/components/comment/index.js
+++ b/src/components/comment/index.js
@@ -25,7 +25,7 @@ function Comment(props) {
     </p>
     <p className={cn('text')}>{props.text}</p>
     <p>
-      <span className={cn('answer')} onClick={clickHandle}>Ответить</span>
+      <span className={cn('answer')} onClick={clickHandle}>{props.answerLabel}</span>
     </p>
   </div>)
 }
@@ -47,10 +47,12 @@ Comment.propTypes = {
   isDeleted: PropTypes.bool,
   offset: PropTypes.number,
   answer: PropTypes.func,
+  answerLabel: PropTypes.string,
 }
 
 Comment.defaultProps = {
   answer: () => {},
+  answerLabel: 'Ответить'
 }
 
 export default Comment;

--- a/src/components/comment/style.css
+++ b/src/components/comment/style.css
@@ -1,0 +1,30 @@
+.Comment {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.Comment p {
+  margin: 0;
+  padding: 0;
+}
+
+.Comment-title {
+  display: flex;
+  gap: 10px;
+  font-size: 12px;
+}
+
+.Comment-date {
+  color: #666;
+}
+
+.Comment-text {
+  font-size: 14px;
+}
+
+.Comment-answer {
+  color: #0087E9;
+  font-size: 12px;
+  cursor: pointer;
+}

--- a/src/components/offset/index.js
+++ b/src/components/offset/index.js
@@ -1,0 +1,15 @@
+import PropTypes from "prop-types";
+import './style.css'
+
+function Offset(props) {
+  return (<div className="Offset" style={{paddingInlineStart: `${props.offset * 30}px`}}>
+    {props.children}
+  </div>)
+}
+
+Offset.propTypes = {
+  children: PropTypes.node,
+  offset: PropTypes.number,
+}
+
+export default Offset;

--- a/src/components/offset/style.css
+++ b/src/components/offset/style.css
@@ -1,0 +1,5 @@
+.Offset {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,9 @@ const config = {
   },
   api: {
     baseUrl: ''
+  },
+  i18n: {
+    lang: 'ru',
   }
 }
 

--- a/src/containers/comments-list/index.js
+++ b/src/containers/comments-list/index.js
@@ -1,0 +1,74 @@
+import {useDispatch, useSelector} from "react-redux";
+import PropTypes from "prop-types";
+import Spinner from "../../components/spinner";
+import ArticleComments from "../../components/article-comments";
+import listToTree from "../../utils/list-to-tree";
+import treeToList from "../../utils/tree-to-list";
+import {useCallback, useMemo, useState} from "react";
+import Comment from "../../components/comment/comment";
+import CommentField from "../../components/comment-field";
+
+function CommentsList({articleId}) {
+  const [parent, setParent] = useState({
+    _id: articleId,
+    _type: "article",
+  });
+
+  const dispatch = useDispatch();
+
+  const select = useSelector(state => ({
+    comments: state.comments.data.items,
+    count: state.comments.data.count,
+    waiting: state.comments.waiting,
+  }));
+
+  const comments = {
+    items: useMemo(() => (treeToList(listToTree(select.comments), (item, level) => ({
+      _id: item._id,
+      text: item.text,
+      dateCreate: item.dateCreate,
+      author: item.author,
+      parent: item.parent,
+      isDeleted: item.isDeleted,
+      offset: level - 1,
+    })).slice(1)), [select.comments])
+  };
+
+  const callbacks = {
+    resetParent: useCallback(() => {
+      setParent({
+        _id: articleId,
+        _type: "article",
+      });
+    }, [articleId]),
+    setParent: useCallback((_id) => {
+      setParent({
+        _id,
+        _type: "comment",
+      });
+    }, [setParent])
+  };
+
+  return (<Spinner active={select.waiting}>
+    <ArticleComments title={`Комментарии (${select.count})`}>
+      {select.count > 0 && comments.items.map(comment => (
+        <div key={comment._id}
+             style={{paddingInlineStart: `${comment.offset * 30}px`}}>
+          <Comment {...comment}
+                   answer={callbacks.setParent}/>
+          {parent._id === comment._id && <CommentField label="Новый ответ"
+                                                       labelSend="Отправить"
+                                                       labelCancel="Отмена"
+                                                       onReset={callbacks.resetParent}/>}
+        </div>))}
+      {parent._id === articleId && (<CommentField label="Новый комментарий"
+                                                  labelSend="Отправить"/>)}
+    </ArticleComments>
+  </Spinner>);
+}
+
+CommentsList.propTypes = {
+  articleId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+export default CommentsList;

--- a/src/containers/comments-list/index.js
+++ b/src/containers/comments-list/index.js
@@ -70,7 +70,7 @@ function CommentsList({articleId}) {
   return (<Spinner active={select.waiting}>
     <ArticleComments title={`Комментарии (${select.count})`}>
       {select.count > 0 && comments.items.map(comment => (
-        <Offset key={comment._id}>
+        <Offset key={comment._id} offset={comment.offset}>
           <Comment {...comment}
                    answer={callbacks.setParent}/>
           {parent._id === comment._id && (storeSelect.exists ? (<CommentField label="Новый ответ"

--- a/src/containers/comments-list/index.js
+++ b/src/containers/comments-list/index.js
@@ -6,15 +6,18 @@ import ArticleComments from "../../components/article-comments";
 import listToTree from "../../utils/list-to-tree";
 import treeToList from "../../utils/tree-to-list";
 import {useCallback, useMemo, useState} from "react";
-import Comment from "../../components/comment/comment";
+import Comment from "../../components/comment";
 import CommentField from "../../components/comment-field";
 import commentsActions from "../../store-redux/comments/actions";
 import {useNavigate} from "react-router-dom";
 import CommentFallback from "../../components/comment-fallback";
 import Offset from "../../components/offset";
+import useTranslate from "../../hooks/use-translate";
 
 
 function CommentsList({articleId}) {
+  const {t} = useTranslate();
+
   const [parent, setParent] = useState({
     _id: articleId,
     _type: "article",
@@ -68,28 +71,32 @@ function CommentsList({articleId}) {
   };
 
   return (<Spinner active={select.waiting}>
-    <ArticleComments title={`Комментарии (${select.count})`}>
+    <ArticleComments title={`${t("articleComments.title")} (${select.count})`}>
       {select.count > 0 && comments.items.map(comment => (
-        <Offset key={comment._id} offset={comment.offset}>
+        <Offset key={comment._id}
+                offset={comment.offset}>
           <Comment {...comment}
-                   answer={callbacks.setParent}/>
-          {parent._id === comment._id && (storeSelect.exists ? (<CommentField label="Новый ответ"
-                                                                              labelSend="Отправить"
-                                                                              labelCancel="Отмена"
+                   answer={callbacks.setParent}
+                   answerLabel={t("comment.answer")}/>
+          {parent._id === comment._id && (storeSelect.exists ? (<CommentField label={t("comment.commentField.label")}
+                                                                              labelSend={t("comment.commentField.labelSend")}
+                                                                              labelCancel={t("comment.commentField.labelCancel")}
                                                                               onReset={callbacks.resetParent}
-                                                                              onSubmit={callbacks.addComment}/>) : (
-            <CommentFallback loginLabel="Войдите"
-                             text=", чтобы иметь возможность ответить. "
-                             reset="Отмена"
+                                                                              onSubmit={callbacks.addComment}
+                                                                              placeholder={t("commentField.placeholder")}/>) : (
+            <CommentFallback loginLabel={t("comment.commentFallback.loginLabel")}
+                             text={t("comment.commentFallback.text")}
+                             reset={t("comment.commentFallback.reset")}
                              signInAction={callbacks.onSignIn}
                              resetAction={callbacks.resetParent}/>))}
 
         </Offset>))}
-      {parent._id === articleId && (storeSelect.exists ? (<CommentField label="Новый комментарий"
-                                                                        labelSend="Отправить"
-                                                                        onSubmit={callbacks.addComment}/>) : (
-        <CommentFallback loginLabel="Войдите"
-                         text=", чтобы иметь возможность комментировать. "
+      {parent._id === articleId && (storeSelect.exists ? (<CommentField label={t("commentField.label")}
+                                                                        labelSend={t("commentField.labelSend")}
+                                                                        onSubmit={callbacks.addComment}
+                                                                        placeholder={t("commentField.placeholder")}/>) : (
+        <CommentFallback loginLabel={t("commentFallback.loginLabel")}
+                         text={t("commentFallback.text")}
                          signInAction={callbacks.onSignIn}
         />))}
     </ArticleComments>

--- a/src/containers/navigation/index.js
+++ b/src/containers/navigation/index.js
@@ -31,18 +31,18 @@ function Navigation() {
   }
 
   // Функция для локализации текстов
-  const {t} = useTranslate();
+  const {lang, t} = useTranslate();
 
   const options = {
     menu: useMemo(() => ([
       {key: 1, title: t('menu.main'), link: '/'},
-    ]), [t])
+    ]), [lang, t])
   };
 
   return (
     <SideLayout side='between'>
       <Menu items={options.menu} onNavigate={callbacks.onNavigate}/>
-      <BasketTool onOpen={callbacks.openModalBasket} amount={select.amount} sum={select.sum} t={t}/>
+      <BasketTool onOpen={callbacks.openModalBasket} amount={select.amount} sum={select.sum} t={t} lang={lang}/>
     </SideLayout>
   );
 }

--- a/src/hooks/use-translate.js
+++ b/src/hooks/use-translate.js
@@ -1,9 +1,17 @@
-import {useCallback, useContext} from 'react';
+import {useCallback, useContext, useSyncExternalStore} from "react";
 import {I18nContext} from '../i18n/context';
+import useServices from "./use-services";
 
 /**
  * Хук возвращает функцию для локализации текстов, код языка и функцию его смены
  */
 export default function useTranslate() {
-  return useContext(I18nContext);
+  // return useContext(I18nContext);
+  const i18n = useServices().i18n;
+  const state = useSyncExternalStore(i18n.subscribe, i18n.getState)
+  return {
+    t: i18n.t,
+    lang: state.lang,
+    setLang: i18n.setLang,
+  }
 }

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,64 @@
+import * as translations from "./translations";
+
+class I18n {
+  listeners = new Set();
+  constructor(services, config={}, initialState={config: {lang: 'ru'}}) {
+    this.services = services;
+    this.config = config;
+    if (this.config.lang) {
+      this.setLang(this.config.lang)
+    }
+
+    this.setLang = this.setLang.bind(this);
+    this.translate = this.translate.bind(this);
+    this.notify = this.notify.bind(this);
+  }
+
+  setLang(lang) {
+    this.config = {
+      ...this.config,
+      lang,
+    }
+    this.services.api.defaultHeaders = {
+      ...this.services.api.defaultHeaders,
+      'X-Lang': lang,
+    }
+    this.notify();
+  }
+
+  get lang() {
+    return this.config.lang;
+  }
+
+  translate(lang, text, plural) {
+    let result = translations[lang] && (text in translations[lang])
+      ? translations[lang][text]
+      : text;
+
+    if (typeof plural !== 'undefined') {
+      const key = new Intl.PluralRules(lang).select(plural);
+      if (key in result) {
+        result = result[key];
+      }
+    }
+
+    return result;
+  }
+
+  t = (text, number) => {
+    return this.translate(this.lang, text, number)
+  }
+
+  getState = () => {
+    return this.config;
+  };
+  subscribe = (listener) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+  notify = () => {
+    this.listeners.forEach(listener => listener());
+  };
+}
+
+export default I18n;

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -20,5 +20,18 @@
   "auth.password": "Password",
   "auth.signIn": "Sign in",
   "session.signIn": "Sign In",
-  "session.signOut": "Sign Out"
+  "session.signOut": "Sign Out",
+  "comment.answer": "Answer",
+  "comment.commentField.label": "New Answer",
+  "comment.commentField.labelSend": "Send",
+  "comment.commentField.labelCancel": "Cancel",
+  "comment.commentFallback.loginLabel": "Sign In",
+  "comment.commentFallback.text": " to add answer ",
+  "comment.commentFallback.reset": "Cancel",
+  "commentField.label": "New Comment",
+  "commentField.labelSend": "Send",
+  "commentField.placeholder": "Text",
+  "commentFallback.loginLabel": "Sign In",
+  "commentFallback.text": " to add comment ",
+  "articleComments.title": "Comments"
 }

--- a/src/i18n/translations/ru.json
+++ b/src/i18n/translations/ru.json
@@ -22,5 +22,18 @@
   "auth.password": "Пароль",
   "auth.signIn": "Войти",
   "session.signIn": "Вход",
-  "session.signOut": "Выход"
+  "session.signOut": "Выход",
+  "comment.answer": "Ответить",
+  "comment.commentField.label": "Новый ответ",
+  "comment.commentField.labelSend": "Отправить",
+  "comment.commentField.labelCancel": "Отмена",
+  "comment.commentFallback.loginLabel": "Войдите",
+  "comment.commentFallback.text": ", чтобы иметь возможность ответить. ",
+  "comment.commentFallback.reset": "Отмена",
+  "commentField.label": "Новый комментарий",
+  "commentField.labelSend": "Отправить",
+  "commentField.placeholder": "Текст",
+  "commentFallback.loginLabel": "Войдите",
+  "commentFallback.text": ", чтобы иметь возможность комментировать. ",
+  "articleComments.title": "Комментарии"
 }

--- a/src/services.js
+++ b/src/services.js
@@ -1,6 +1,7 @@
 import APIService from './api';
 import Store from './store';
 import createStoreRedux from './store-redux';
+import I18n from "./i18n";
 
 class Services {
 
@@ -38,6 +39,13 @@ class Services {
       this._redux = createStoreRedux(this, this.config.redux);
     }
     return this._redux;
+  }
+
+  get i18n() {
+    if (!this._i18n) {
+      this._i18n = new I18n(this, this.config.i18n);
+    }
+    return this._i18n;
   }
 }
 

--- a/src/store-redux/comments/actions.js
+++ b/src/store-redux/comments/actions.js
@@ -18,5 +18,32 @@ export default {
         dispatch({type: CommentsConstants.LOAD_ERROR, payload: {e}});
       }
     };
+  },
+
+  addComment: ({text, parent, id}) => {
+    return async (dispatch, getState, services) => {
+      const token = localStorage.getItem('token');
+      if (!token) return;
+      try {
+        dispatch({type: CommentsConstants.LOAD_START});
+        await services.api.request({
+          url: `/api/v1/comments`,
+          method: 'POST',
+          headers: {
+            'X-Token': token,
+          },
+          body: JSON.stringify({
+            text,
+            parent,
+          })
+        })
+        const res = await services.api.request({
+          url: `/api/v1/comments?fields=items(_id,text,dateCreate,author(profile(name)),parent(_id,_type),isDeleted),count&limit=*&search[parent]=${id}`
+        });
+        dispatch({type: CommentsConstants.LOAD_SUCCESS, payload: {data: res.data.result}});
+      } catch (e) {
+        dispatch({type: CommentsConstants.LOAD_ERROR, payload: e.message});
+      }
+    }
   }
 };

--- a/src/store-redux/comments/actions.js
+++ b/src/store-redux/comments/actions.js
@@ -1,0 +1,22 @@
+import {CommentsConstants} from "./constants";
+
+export default {
+  load: (id) => {
+    return async (dispatch, getState, services) => {
+      // Сброс текущего товара и установка признака ожидания загрузки
+      dispatch({type: CommentsConstants.LOAD_START});
+
+      try {
+        const res = await services.api.request({
+          url: `/api/v1/comments?fields=items(_id,text,dateCreate,author(profile(name)),parent(_id,_type),isDeleted),count&limit=*&search[parent]=${id}`
+        });
+        // Товар загружен успешно
+        dispatch({type: CommentsConstants.LOAD_SUCCESS, payload: {data: res.data.result}});
+
+      } catch (e) {
+        //Ошибка загрузки
+        dispatch({type: CommentsConstants.LOAD_ERROR, payload: {e}});
+      }
+    };
+  }
+};

--- a/src/store-redux/comments/constants.js
+++ b/src/store-redux/comments/constants.js
@@ -2,4 +2,5 @@ export const CommentsConstants = {
   LOAD_START: 'comments/load-start',
   LOAD_SUCCESS: 'comments/load-success',
   LOAD_ERROR: 'comments/load-error',
+  ADD_COMMENT: 'comments/add-comment',
 }

--- a/src/store-redux/comments/constants.js
+++ b/src/store-redux/comments/constants.js
@@ -1,0 +1,5 @@
+export const CommentsConstants = {
+  LOAD_START: 'comments/load-start',
+  LOAD_SUCCESS: 'comments/load-success',
+  LOAD_ERROR: 'comments/load-error',
+}

--- a/src/store-redux/comments/reducer.js
+++ b/src/store-redux/comments/reducer.js
@@ -3,24 +3,27 @@ import {CommentsConstants} from "./constants";
 const initialData = {
   count: 0,
   items: [],
-}
+};
 
 export const initialState = {
   data: initialData,
   waiting: false,
-  error: '',
-}
+  error: "",
+};
 
 function reducer(state = initialState, action) {
   switch (action.type) {
     case CommentsConstants.LOAD_START:
-      return {...state, data: initialData, waiting: true, error: ''};
+      return {...state, data: initialData, waiting: true, error: ""};
 
     case CommentsConstants.LOAD_SUCCESS:
-      return {...state, data: action.payload.data, waiting: false, error: ''};
+      return {...state, data: action.payload.data || initialData, waiting: false, error: ""};
 
     case CommentsConstants.LOAD_ERROR:
       return {...state, data: initialData, waiting: false, error: action.payload.error.message};
+
+    case CommentsConstants.ADD_COMMENT:
+      return initialState;
 
     default:
       return state;

--- a/src/store-redux/comments/reducer.js
+++ b/src/store-redux/comments/reducer.js
@@ -1,0 +1,30 @@
+import {CommentsConstants} from "./constants";
+
+const initialData = {
+  count: 0,
+  items: [],
+}
+
+export const initialState = {
+  data: initialData,
+  waiting: false,
+  error: '',
+}
+
+function reducer(state = initialState, action) {
+  switch (action.type) {
+    case CommentsConstants.LOAD_START:
+      return {...state, data: initialData, waiting: true, error: ''};
+
+    case CommentsConstants.LOAD_SUCCESS:
+      return {...state, data: action.payload.data, waiting: false, error: ''};
+
+    case CommentsConstants.LOAD_ERROR:
+      return {...state, data: initialData, waiting: false, error: action.payload.error.message};
+
+    default:
+      return state;
+  }
+}
+
+export default reducer;

--- a/src/store-redux/exports.js
+++ b/src/store-redux/exports.js
@@ -1,2 +1,3 @@
 export {default as article} from './article/reducer';
 export {default as modals} from './modals/reducer';
+export {default as comments} from './comments/reducer';

--- a/src/utils/list-to-tree/index.js
+++ b/src/utils/list-to-tree/index.js
@@ -20,9 +20,12 @@ export default function listToTree(list, key = '_id') {
     }
 
     // Если элемент имеет родителя, то добавляем его в подчиненные родителя
-    if (item.parent?._id) {
+    if (item.parent?.[key]) {
       // Если родителя ещё нет в индексе, то индекс создаётся, ведь _id родителя известен
-      if (!trees[item.parent._id]) trees[item.parent[key]] = {children: []};
+      if (!trees[item.parent[key]]) {
+        trees[item.parent[key]] = {children: []};
+        roots[item.parent[key]] = trees[item.parent[key]]
+      }
       // Добавления в подчиненные родителя
       trees[item.parent[key]].children.push(trees[item[key]]);
       // Так как элемент добавлен к родителю, то он уже не является корневым

--- a/src/utils/list-to-tree/index.spec.js
+++ b/src/utils/list-to-tree/index.spec.js
@@ -40,6 +40,7 @@ describe('listToTree', () => {
 
   test('test2', () => {
     const list = [
+      {_id: 0, title: 'Сюрприз =)', parent: {_id: 11}},
       {_id: 2, title: 'Электроника', parent: null},
       {_id: 3, title: 'Телефоны', parent: {_id: 2}},
       {_id: 8, title: 'Книги', parent: null},
@@ -50,7 +51,6 @@ describe('listToTree', () => {
       {_id: 11, title: 'Комиксы', parent: {_id: 8}},
       {_id: 4, title: 'Смартфоны', parent: {_id: 3}},
       {_id: 5, title: 'Аксессуары', parent: {_id: 4}},
-      {_id: 12, title: 'Сюрприз =)', parent: {_id: 11}},
     ]
 
     expect(listToTree(list)).toEqual([
@@ -75,9 +75,46 @@ describe('listToTree', () => {
           {_id: 10, title: 'Художественная', parent: {_id: 8}, children: []},
           {
             _id: 11, title: 'Комиксы', parent: {_id: 8}, children: [
-              {_id: 12, title: 'Сюрприз =)', parent: {_id: 11}, children: []},
+              {_id: 0, title: 'Сюрприз =)', parent: {_id: 11}, children: []},
             ]
           }
+        ]
+      }
+    ]);
+  });
+
+  test('test3', () => {
+    const list = [
+      { _id: 3, title: "Телефоны", parent: { _id: 2 } },
+      { _id: 2, title: "Электроника", parent: null },
+      { _id: 9, title: "Учебники", parent: { _id: 8 } },
+      { _id: 8, title: "Книги", parent: null },
+      { _id: 6, title: "Ноутбуки", parent: { _id: 2 } },
+      { _id: 7, title: "Телевизоры", parent: { _id: 2 } },
+      { _id: 10, title: "Художественная", parent: { _id: 8 } },
+      { _id: 11, title: "Комиксы", parent: { _id: 8 } },
+      { _id: 4, title: "Смартфоны", parent: { _id: 3 } },
+      { _id: 5, title: "Аксессуары", parent: { _id: 3 } },
+    ];
+
+    expect(listToTree(list)).toEqual([
+      {
+        _id: 2, title: 'Электроника', parent: null, children: [
+          {
+            _id: 3, title: 'Телефоны', parent: {_id: 2}, children: [
+              {_id: 4, title: 'Смартфоны', parent: {_id: 3}, children: []},
+              {_id: 5, title: 'Аксессуары', parent: {_id: 3}, children: []}
+            ]
+          },
+          {_id: 6, title: 'Ноутбуки', parent: {_id: 2}, children: []},
+          {_id: 7, title: 'Телевизоры', parent: {_id: 2}, children: []}
+        ]
+      },
+      {
+        _id: 8, title: 'Книги', parent: null, children: [
+          {_id: 9, title: 'Учебники', parent: {_id: 8}, children: []},
+          {_id: 10, title: 'Художественная', parent: {_id: 8}, children: []},
+          {_id: 11, title: 'Комиксы', parent: {_id: 8}, children: []}
         ]
       }
     ]);


### PR DESCRIPTION
## Student: 
- Щербаков Илья

## Screenshot: 
![image](https://github.com/ylabio/react-webinar-3/assets/86749581/a2d2ea7e-db27-47e6-9063-ce65a54ec3d9)
![image](https://github.com/ylabio/react-webinar-3/assets/86749581/fbbbf3dd-9821-4aca-87ea-91c974e16684)


## Done / Deadline
 20.12.2023 / 21.12.2023

## Tasks: 
- [x] На странице товара добавить пользовательские комментарии. 
- [x] Комментарии отображаются сразу все в виде иерархии. В каждом комментарии имя автора, дата, текст и ссылка для ответа на комментарий.
- [x] Ответить или написать новый комментарий может только авторизованный пользователь. Для неавторизованного вывести текст “Войдите, чтобы иметь возможность комментировать”. 
- [x] Форма для написания нового комментария показывается в самом низу под всеми комментариями. А форма ответа на комментарий под соответствующем комментарием. Одновременно отображается только одна форма. 
- [x] Комментарии выбираются из АПИ, в поле parent указывается id товара, который комментируется, чьи комментарии хотим выбрать.
- [x] Для создания нового комментария в parent указывается id товара. Но если создаётся ответ на другой комментарий, то в parent указывается идентификатор комментария, на который отвечаем.
- [x] В качестве внешнего состояния использовать redux. (подготовленный в коде). Всё переписывать на redux не надо.
- [x] Логику с мультиязычностью перенести в новый сервис I18n. Функция translate будет методом сервиса. Если ей не передавать в аргументах код языка, то используется текущий код языка в сервисе мультиязычности. Текущий код языка (локаль) тоже должен храниться в сервисе мультиязычности. По сути код языка будет состоянием сервиса. Тем самым отказываемся от использования и store и провайдера для хранения кода языка. Придется изменить интеграцию с компонентами - в хуке useTranslate отслеживать изменение кода языка в сервисе мультиязычности, а не в store/провайдере. В хуке useTranslate доступ к сервису мультиязычности реализуется хуком useServices. 

