### PR TITLE
Lecture 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^8.0.7",
+        "react-redux": "^8.1.3",
         "react-router-dom": "^6.11.2",
         "redux": "^4.2.1",
         "redux-thunk": "^2.4.2",
@@ -8147,9 +8147,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-redux": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.7.tgz",
-      "integrity": "sha512-1vRQuCQI5Y2uNmrMXg81RXKiBHY3jBzvCvNmZF437O/Z9/pZ+ba2uYHbemYXb3g8rjsacBGo+/wmfrQKzMhJsg==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -8159,7 +8159,6 @@
         "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
-        "@reduxjs/toolkit": "^1 || ^2.0.0-beta.0",
         "@types/react": "^16.8 || ^17.0 || ^18.0",
         "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
         "react": "^16.8 || ^17.0 || ^18.0",
@@ -8168,9 +8167,6 @@
         "redux": "^4 || ^5.0.0-beta.0"
       },
       "peerDependenciesMeta": {
-        "@reduxjs/toolkit": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         },
@@ -15950,9 +15946,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-redux": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.7.tgz",
-      "integrity": "sha512-1vRQuCQI5Y2uNmrMXg81RXKiBHY3jBzvCvNmZF437O/Z9/pZ+ba2uYHbemYXb3g8rjsacBGo+/wmfrQKzMhJsg==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^8.0.7",
+    "react-redux": "^8.1.3",
     "react-router-dom": "^6.11.2",
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -27,7 +27,11 @@ class APIService {
       headers: {...this.defaultHeaders, ...headers},
       ...options,
     });
-    return {data: await res.json(), status: res.status, headers: res.headers};
+    if (res.ok) {
+      return {data: await res.json(), status: res.status, headers: res.headers};      
+    } else {
+      return {data: {error: res.statusText}, status: res.status, headers: res.headers};
+    }
   }
 
   /**

--- a/src/app/article/index.js
+++ b/src/app/article/index.js
@@ -36,7 +36,7 @@ function Article() {
     comments: state.comments
   }), shallowequal); // Нужно указать функцию для сравнения свойства объекта, так как хуком вернули объект
 
-  const {t} = useTranslate();
+  const {t} = useTranslate(state => ({lang: state.lang}));
 
   const callbacks = {
     // Добавление в корзину

--- a/src/app/article/index.js
+++ b/src/app/article/index.js
@@ -13,6 +13,8 @@ import TopHead from '../../containers/top-head';
 import {useDispatch, useSelector} from 'react-redux';
 import shallowequal from 'shallowequal';
 import articleActions from '../../store-redux/article/actions';
+import commentsActions from '../../store-redux/comments/actions';
+import CommentsList from '../../containers/comments-list';
 
 function Article() {
   const store = useStore();
@@ -25,11 +27,13 @@ function Article() {
   useInit(() => {
     //store.actions.article.load(params.id);
     dispatch(articleActions.load(params.id));
+    dispatch(commentsActions.load(params.id));
   }, [params.id]);
 
   const select = useSelector(state => ({
     article: state.article.data,
-    waiting: state.article.waiting,
+    waiting: state.article.waiting || state.comments.waiting,
+    comments: state.comments
   }), shallowequal); // Нужно указать функцию для сравнения свойства объекта, так как хуком вернули объект
 
   const {t} = useTranslate();
@@ -38,6 +42,8 @@ function Article() {
     // Добавление в корзину
     addToBasket: useCallback(_id => store.actions.basket.addToBasket(_id), [store]),
   }
+
+  //.items.map(items => ({...items, parent: items.parent._id === params.id ? null : items.parent}))
 
   return (
     <PageLayout>
@@ -48,6 +54,7 @@ function Article() {
       <Navigation/>
       <Spinner active={select.waiting}>
         <ArticleCard article={select.article} onAdd={callbacks.addToBasket} t={t}/>
+        <CommentsList parent={{_id: params.id, _type: 'article'}}/>
       </Spinner>
     </PageLayout>
   );

--- a/src/app/basket/index.js
+++ b/src/app/basket/index.js
@@ -48,7 +48,7 @@ function Basket() {
   return (
     <ModalLayout title={t('basket.title')} labelClose={t('basket.close')}
                  onClose={callbacks.closeModal}>
-      <List list={select.list} renderItem={renders.itemBasket}/>
+      <List list={select.list} renderItem={renders.itemBasket} theme='dashed'/>
       <BasketTotal sum={select.sum} t={t}/>
     </ModalLayout>
   );

--- a/src/app/basket/index.js
+++ b/src/app/basket/index.js
@@ -31,7 +31,7 @@ function Basket() {
     }, [store]),
   }
 
-  const {t} = useTranslate();
+  const {t} = useTranslate(state => ({lang: state.lang}));
 
   const renders = {
     itemBasket: useCallback((item) => (

--- a/src/app/login/index.js
+++ b/src/app/login/index.js
@@ -15,7 +15,7 @@ import useInit from '../../hooks/use-init';
 
 function Login() {
 
-  const {t} = useTranslate();
+  const {t} = useTranslate(state => ({lang: state.lang}));
   const location = useLocation();
   const navigate = useNavigate();
   const store = useStore();

--- a/src/app/main/index.js
+++ b/src/app/main/index.js
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {memo, useCallback, useMemo} from 'react';
 import useStore from '../../hooks/use-store';
 import useTranslate from '../../hooks/use-translate';
 import useInit from '../../hooks/use-init';
@@ -14,14 +14,14 @@ function Main() {
 
   const store = useStore();
 
+  const {t} = useTranslate(state => ({lang: state.lang}));
+
   useInit(async () => {
     await Promise.all([
       store.actions.catalog.initParams(),
       store.actions.categories.load()
     ]);
   }, [], true);
-
-  const {t} = useTranslate();
 
   return (
     <PageLayout>

--- a/src/app/profile/index.js
+++ b/src/app/profile/index.js
@@ -25,7 +25,7 @@ function Profile() {
     waiting: state.profile.waiting,
   }));
 
-  const {t} = useTranslate();
+  const {t} = useTranslate(state => ({lang: state.lang}));
 
   return (
     <PageLayout>

--- a/src/components/comment-form/index.js
+++ b/src/components/comment-form/index.js
@@ -20,13 +20,15 @@ function CommentForm(props) {
       { props.exists
           ? <form onSubmit={callbacks.onSubmit} disabled={props.disabled}>
               <h3>{props.title}</h3>
-              <textarea rows='4' onChange={e => { props.setText(e.target.value); }} placeholder={props.placeholder} value={props.text} autoFocus={props.autoFocus}/>
+              <textarea rows='4' onChange={e => { props.setText(e.target.value); }} placeholder={props.t('comments.text')} value={props.text} autoFocus={props.autoFocus}/>
               <div className={cn('buttons')}>
-                <button type='submit'>{props.labelSend}</button>
-                { props.isCancelable && <button onClick={props.onCancel}>{props.labelCancel}</button> }
+                <button type='submit'>{props.t('comments.send')}</button>
+                { props.isCancelable && <button onClick={props.onCancel}>{props.t('comments.cancel')}</button> }
               </div>
             </form>
-          : <div className={cn('invite')}><Link to={props.inviteUrl}>Войдите</Link>, чтобы иметь возможность комментировать</div>
+          : <div className={cn('invite')}>
+              <Link to={props.inviteUrl}>{props.t('comments.inviteAnchor')}</Link>{props.t('comments.invite').replace(props.t('comments.inviteAnchor'), '')}
+            </div>
       }
     </div>
  
@@ -38,14 +40,12 @@ CommentForm.propTypes = {
   theme: PropTypes.string,
   autoFocus: PropTypes.bool,
   paddingLeft: PropTypes.number,
-  placeholder: PropTypes.string,
-  labelSend: PropTypes.string,
-  labelCancel: PropTypes.string,
   isCancelable: PropTypes.bool,
   exists: PropTypes.bool,
   inviteUrl: PropTypes.string,
   disabled: PropTypes.bool,
   text: PropTypes.string.isRequired,
+  t: PropTypes.func,
   setText: PropTypes.func.isRequired,
   onSubmit: PropTypes.func,
   onCancel: PropTypes.func
@@ -56,13 +56,11 @@ CommentForm.defaultProps = {
   theme: '',
   autoFocus: false,
   paddingLeft: 40,
-  placeholder: 'Текст',
-  labelSend: 'Отправить',
-  labelCancel: 'Отмена',
   isCancelable: false,
   exists: false,
   inviteUrl: '/login/',
   disabled: false,
+  t: (text) => text,
   onSubmit: () => {},
   onCancel: () => {}
 }

--- a/src/components/comment-form/index.js
+++ b/src/components/comment-form/index.js
@@ -1,0 +1,65 @@
+import {memo, useState} from 'react';
+import PropTypes from 'prop-types';
+import {cn as bem} from '@bem-react/classname';
+import './style.css';
+import { Link } from 'react-router-dom';
+
+function CommentForm(props) {
+
+  const cn = bem('CommentForm');
+
+  const [text, setText] = useState('');
+
+  const callbacks = {
+    onSubmit: (e) => {
+      e.preventDefault();
+      props.onSubmit(text);
+      setText('');
+    }
+  }
+
+  return (
+    <div className={cn()}>
+      { props.exists
+          ? <form onSubmit={callbacks.onSubmit} disabled={props.disabled}>
+              <h3>{props.title}</h3>
+              <textarea rows='4' onChange={e => setText(e.target.value)} placeholder={props.placeholder} value={text}/>
+              <div className={cn('buttons')}>
+                <button type='submit'>{props.labelSend}</button>
+                { props.isCancelable && <button onClick={props.onCancel}>{props.labelCancel}</button> }
+              </div>
+            </form>
+          : <div className={cn('invite')}><Link to={props.inviteUrl}>Войдите</Link>, чтобы иметь возможность комментировать</div>
+      }
+    </div>
+ 
+  );
+}
+
+CommentForm.propTypes = {
+  title: PropTypes.string,
+  placeholder: PropTypes.string,
+  labelSend: PropTypes.string,
+  labelCancel: PropTypes.string,
+  isCancelable: PropTypes.bool,
+  exists: PropTypes.bool,
+  inviteUrl: PropTypes.string,
+  disabled: PropTypes.bool,
+  onSubmit: PropTypes.func,
+  onCancel: PropTypes.func
+};
+
+CommentForm.defaultProps = {
+  title: 'Новый комментарий',
+  placeholder: 'Текст',
+  labelSend: 'Отправить',
+  labelCancel: 'Отмена',
+  isCancelable: false,
+  exists: false,
+  inviteUrl: '/login/',
+  disabled: false,
+  onSubmit: () => {},
+  onCancel: () => {}
+}
+
+export default memo(CommentForm);

--- a/src/components/comment-form/index.js
+++ b/src/components/comment-form/index.js
@@ -1,4 +1,4 @@
-import {memo, useState} from 'react';
+import {memo} from 'react';
 import PropTypes from 'prop-types';
 import {cn as bem} from '@bem-react/classname';
 import './style.css';
@@ -8,22 +8,19 @@ function CommentForm(props) {
 
   const cn = bem('CommentForm');
 
-  const [text, setText] = useState('');
-
   const callbacks = {
     onSubmit: (e) => {
       e.preventDefault();
-      props.onSubmit(text);
-      setText('');
+      props.onSubmit();
     }
   }
 
   return (
-    <div className={cn()}>
+    <div className={cn({theme: props.theme})} style={{paddingLeft: props.paddingLeft + 'px'}}>
       { props.exists
           ? <form onSubmit={callbacks.onSubmit} disabled={props.disabled}>
               <h3>{props.title}</h3>
-              <textarea rows='4' onChange={e => setText(e.target.value)} placeholder={props.placeholder} value={text}/>
+              <textarea rows='4' onChange={e => { props.setText(e.target.value); }} placeholder={props.placeholder} value={props.text} autoFocus={props.autoFocus}/>
               <div className={cn('buttons')}>
                 <button type='submit'>{props.labelSend}</button>
                 { props.isCancelable && <button onClick={props.onCancel}>{props.labelCancel}</button> }
@@ -38,6 +35,9 @@ function CommentForm(props) {
 
 CommentForm.propTypes = {
   title: PropTypes.string,
+  theme: PropTypes.string,
+  autoFocus: PropTypes.bool,
+  paddingLeft: PropTypes.number,
   placeholder: PropTypes.string,
   labelSend: PropTypes.string,
   labelCancel: PropTypes.string,
@@ -45,12 +45,17 @@ CommentForm.propTypes = {
   exists: PropTypes.bool,
   inviteUrl: PropTypes.string,
   disabled: PropTypes.bool,
+  text: PropTypes.string.isRequired,
+  setText: PropTypes.func.isRequired,
   onSubmit: PropTypes.func,
   onCancel: PropTypes.func
 };
 
 CommentForm.defaultProps = {
   title: 'Новый комментарий',
+  theme: '',
+  autoFocus: false,
+  paddingLeft: 40,
   placeholder: 'Текст',
   labelSend: 'Отправить',
   labelCancel: 'Отмена',

--- a/src/components/comment-form/style.css
+++ b/src/components/comment-form/style.css
@@ -1,5 +1,10 @@
 .CommentForm {
-  padding: 30px 40px;
+  padding: 10px 40px 30px 40px;
+}
+
+.CommentForm_theme_embed {
+  padding-top: 30px;
+  padding-bottom: 10px;
 }
 
 .CommentForm h3 {

--- a/src/components/comment-form/style.css
+++ b/src/components/comment-form/style.css
@@ -1,0 +1,26 @@
+.CommentForm {
+  padding: 30px 40px;
+}
+
+.CommentForm h3 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.CommentForm textarea {
+  width: 100%;
+  margin-block: 10px;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 14px;
+}
+
+.CommentForm-buttons {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.CommentForm-invite {
+  font-size: 16;
+}

--- a/src/components/comments/index.js
+++ b/src/components/comments/index.js
@@ -1,0 +1,42 @@
+import {memo} from 'react';
+import PropTypes from 'prop-types';
+import {cn as bem} from '@bem-react/classname';
+import List from '../../components/list';
+import './style.css';
+
+function Comments(props) {
+  const cn = bem('Comments');
+
+  return (
+    <div className={cn()}>
+      <h2>{props.title}</h2>
+      <List list={props.items} renderItem={props.renderItem}/>
+    </div>
+  );
+}
+
+Comments.propTypes = {
+  count: PropTypes.number,
+  items: PropTypes.arrayOf(PropTypes.shape({
+    _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    author: PropTypes.shape({
+      _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      profile: PropTypes.shape({name: PropTypes.string})
+    }),
+    dateCreate: PropTypes.string,
+    text: PropTypes.string,
+    isDeleted: PropTypes.bool,
+  })),
+  lang: PropTypes.string,
+  title: PropTypes.string,
+  renderItem: PropTypes.func.isRequired
+};
+
+Comments.defaultProps = {
+  count: 0,
+  items: [],
+  lang: 'ru',
+  title: 'Комментарии'
+}
+
+export default memo(Comments);

--- a/src/components/comments/index.js
+++ b/src/components/comments/index.js
@@ -26,6 +26,7 @@ Comments.propTypes = {
     dateCreate: PropTypes.string,
     text: PropTypes.string,
     isDeleted: PropTypes.bool,
+    paddingLeft: PropTypes.number
   })),
   lang: PropTypes.string,
   title: PropTypes.string,

--- a/src/components/comments/style.css
+++ b/src/components/comments/style.css
@@ -1,0 +1,9 @@
+.Comments {
+  padding: 40px 40px 20px 40px;
+}
+
+.Comments h2 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+}

--- a/src/components/item-comment/index.js
+++ b/src/components/item-comment/index.js
@@ -24,7 +24,7 @@ function ItemComment(props) {
       <div className={cn('text')}>
         {props.item.text}
       </div>
-      <a href='#' className={cn('link')} onClick={callbacks.onAnswer}>Ответить</a>
+      <a href='#' className={cn('link')} onClick={callbacks.onAnswer}>{props.labelAnswer}</a>
     </div>
   )
 }
@@ -42,11 +42,13 @@ ItemComment.propTypes = {
     paddingLeft: PropTypes.number,
   }).isRequired,
   lang: PropTypes.string,
+  labelAnswer: PropTypes.string,
   onAnswer: PropTypes.func
 }
 
 ItemComment.defaultProps = {
   lang: 'ru',
+  labelAnswer: 'Ответить',
   onAnswer: () => {}
 }
 

--- a/src/components/item-comment/index.js
+++ b/src/components/item-comment/index.js
@@ -1,0 +1,53 @@
+import {memo} from 'react';
+import {cn as bem} from '@bem-react/classname';
+import PropTypes from 'prop-types';
+import './style.css';
+import dateFormat from '../../utils/date-format';
+
+function ItemComment(props) {
+
+  const cn = bem('ItemComment');
+  
+  const callbacks = {
+    onAnswer: (e) => {
+      e.preventDefault();
+      props.onAnswer({_id: props.item._id, _type: 'comment'});
+    }
+  };
+
+  return (
+    <div className={cn()} style={{paddingLeft: props.item.padding + 'px'}}>
+      <div className={cn('meta')}>
+        <div className={cn('author')}>{props.item.author.profile.name}</div>
+        <div className={cn('date')}>{ dateFormat(props.item.dateCreate, props.lang, {year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit'}).replace(' г.', '') }</div>
+      </div>
+      <div className={cn('text')}>
+        {props.item.text}
+      </div>
+      <a href='#' className={cn('link')} onClick={callbacks.onAnswer}>Ответить</a>
+    </div>
+  )
+}
+
+ItemComment.propTypes = {
+  item: PropTypes.shape({
+    _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    author: PropTypes.shape({
+      _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      profile: PropTypes.shape({name: PropTypes.string})
+    }),
+    dateCreate: PropTypes.string,
+    text: PropTypes.string,
+    isDeleted: PropTypes.bool,
+    padding: PropTypes.number,
+  }).isRequired,
+  lang: PropTypes.string,
+  onAnswer: PropTypes.func
+}
+
+ItemComment.defaultProps = {
+  lang: 'ru',
+  onAnswer: () => {}
+}
+
+export default memo(ItemComment);

--- a/src/components/item-comment/index.js
+++ b/src/components/item-comment/index.js
@@ -16,7 +16,7 @@ function ItemComment(props) {
   };
 
   return (
-    <div className={cn()} style={{paddingLeft: props.item.padding + 'px'}}>
+    <div className={cn()} style={{paddingLeft: props.item.paddingLeft + 'px'}}>
       <div className={cn('meta')}>
         <div className={cn('author')}>{props.item.author.profile.name}</div>
         <div className={cn('date')}>{ dateFormat(props.item.dateCreate, props.lang, {year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit'}).replace(' г.', '') }</div>
@@ -39,7 +39,7 @@ ItemComment.propTypes = {
     dateCreate: PropTypes.string,
     text: PropTypes.string,
     isDeleted: PropTypes.bool,
-    padding: PropTypes.number,
+    paddingLeft: PropTypes.number,
   }).isRequired,
   lang: PropTypes.string,
   onAnswer: PropTypes.func

--- a/src/components/item-comment/style.css
+++ b/src/components/item-comment/style.css
@@ -1,0 +1,24 @@
+.ItemComment {
+  margin-top: 30px;
+}
+
+.ItemComment-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  font-size: 12px;
+}
+
+.ItemComment-author {
+  font-weight: 700;
+}
+
+.ItemComment-date {
+  color: #666;
+}
+
+.ItemComment-link {
+  display: block;
+  margin-top: 10px;
+}

--- a/src/components/list/index.js
+++ b/src/components/list/index.js
@@ -1,13 +1,16 @@
 import {memo} from 'react';
 import PropTypes from 'prop-types';
-import Item from '../item';
+import {cn as bem} from '@bem-react/classname';
 import './style.css';
 
-function List({list, renderItem}) {
+function List({list, renderItem, theme}) {
+
+  const cn = bem('List');
+  
   return (
-    <div className='List'>{
+    <div className={cn()}>{
       list.map(item =>
-        <div key={item._id} className='List-item'>
+        <div key={item._id} className={cn('item', {theme: theme})}>
           {renderItem(item)}
         </div>
       )}
@@ -20,11 +23,13 @@ List.propTypes = {
     _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
   })).isRequired,
   renderItem: PropTypes.func,
+  theme: PropTypes.string
 };
 
 List.defaultProps = {
   renderItem: (item) => {
   },
+  theme: ''
 }
 
 export default memo(List);

--- a/src/components/list/index.js
+++ b/src/components/list/index.js
@@ -10,7 +10,7 @@ function List({list, renderItem, theme}) {
   return (
     <div className={cn()}>{
       list.map(item =>
-        <div key={item._id} className={cn('item', {theme: theme})}>
+        <div key={item._id} className={cn('item', {theme})}>
           {renderItem(item)}
         </div>
       )}

--- a/src/components/list/style.css
+++ b/src/components/list/style.css
@@ -1,11 +1,7 @@
-.List {
-
-}
-
-.List-item {
+.List-item_theme_dashed {
   border-bottom: 1px dashed #ccc;
 }
 
-.List-item:first-child {
+.List-item_theme_dashed:first-child {
   border-top: 1px dashed #ccc;
 }

--- a/src/components/page-layout/style.css
+++ b/src/components/page-layout/style.css
@@ -13,3 +13,12 @@ body {
   box-sizing: border-box;
   box-shadow: 0 0 15px 5px #0000003b;
 }
+
+a {
+  color: #0087e9;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,9 @@ const config = {
   },
   api: {
     baseUrl: ''
+  },
+  i18n: {
+    lang: 'ru'
   }
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -19,7 +19,8 @@ const config = {
     baseUrl: ''
   },
   i18n: {
-    lang: 'ru'
+    lang: 'ru',
+    langHeader: 'X-Lang'
   }
 }
 

--- a/src/containers/catalog-filter/index.js
+++ b/src/containers/catalog-filter/index.js
@@ -50,7 +50,7 @@ function CatalogFilter() {
     ]), [select.categories]),
   };
 
-  const {t} = useTranslate();
+  const {t} = useTranslate(state => ({lang: state.lang}));
 
   return (
     <SideLayout padding='medium'>

--- a/src/containers/catalog-list/index.js
+++ b/src/containers/catalog-list/index.js
@@ -47,7 +47,7 @@ function CatalogList() {
 
   return (
     <Spinner active={select.waiting}>
-      <List list={select.list} renderItem={renders.item}/>
+      <List list={select.list} renderItem={renders.item} theme='dashed'/>
       <Pagination count={select.count} page={select.page} limit={select.limit}
                   onChange={callbacks.onPaginate} makeLink={callbacks.makePaginatorLink}/>
     </Spinner>

--- a/src/containers/catalog-list/index.js
+++ b/src/containers/catalog-list/index.js
@@ -36,7 +36,7 @@ function CatalogList() {
     }, [select.limit, select.sort, select.query])
   }
 
-  const {t} = useTranslate();
+  const {t} = useTranslate(state => ({lang: state.lang}));
 
   const renders = {
     item: useCallback(item => (

--- a/src/containers/comments-list/index.js
+++ b/src/containers/comments-list/index.js
@@ -14,7 +14,7 @@ import commentsActions from '../../store-redux/comments/actions';
 function CommentsList(props) {
 
   const dispatch = useDispatch();
-  const {lang, t} = useTranslate();
+  const {lang, t} = useTranslate(state => ({lang: state.lang}));
 
   const [parent, setParent] = useState(props.parent);
   const [text, setText] = useState('');

--- a/src/containers/comments-list/index.js
+++ b/src/containers/comments-list/index.js
@@ -1,0 +1,114 @@
+import {memo, useCallback, useEffect, useState} from 'react';
+import useSelector from '../../hooks/use-selector';
+import {useDispatch, useSelector as useSelectorRedux} from 'react-redux';
+import useTranslate from '../../hooks/use-translate';
+import PropTypes from 'prop-types';
+import shallowequal from 'shallowequal';
+import ItemComment from '../../components/item-comment';
+import treeToList from '../../utils/tree-to-list';
+import listToTree from '../../utils/list-to-tree';
+import CommentForm from '../../components/comment-form';
+import Comments from '../../components/comments';
+import commentsActions from '../../store-redux/comments/actions';
+
+function CommentsList(props) {
+
+  const dispatch = useDispatch();
+  const {lang, t} = useTranslate();
+
+  const [parent, setParent] = useState(props.parent);
+
+  const session = useSelector(state => ({
+    exists: state.session.exists,
+    user: state.session.user
+  }));
+
+  const select = useSelectorRedux(state => ({
+    items: state.comments.items,
+    count: state.comments.count,
+    waiting: state.comments.waiting,
+    sending: state.comments.sending
+  }), shallowequal);
+
+  const cancelAnswer = () => setParent(props.parent);
+
+  useEffect(
+    () => {
+      if (!select.sending) {
+        cancelAnswer();
+      }
+    },
+    [select.sending]
+  )
+
+  const callbacks = {
+    // Отправка комментария
+    send: useCallback(text => dispatch(commentsActions.send(session.user, parent, text))),
+  }
+
+  const renders = {
+    item: useCallback(item => (
+      <>
+        <ItemComment item={item} lang={lang} onAnswer={setParent}/>
+        { parent._id === item._id &&
+            <CommentForm
+              title={t('comments.newAnswer')}
+              placeholder={t('comments.text')}
+              labelSend={t('comments.send')}
+              labelCancel={t('comments.cancel')}
+              exists={session.exists}
+              onCancel={cancelAnswer}
+              isCancelable={true}
+              inviteUrl='/login/'
+              disabled={select.sending}
+              onSubmit={callbacks.send}/>
+        }
+      </>
+    ), [lang, parent]),
+  };
+
+  const items = treeToList(listToTree(select.items), (item, level) => (
+    {...item, padding: (level - 1) * 30}
+  )).splice(1);
+
+  return (
+    <>
+      <Comments items={items} renderItem={renders.item} title={t('comments') + ` (${select.count})`} />
+      { parent._id === props.parent._id &&
+          <CommentForm
+            title={t('comments.newComment')}
+            placeholder={t('comments.text')}
+            labelSend={t('comments.send')}
+            exists={session.exists}
+            inviteUrl='/login/'
+            disabled={select.sending}
+            onSubmit={callbacks.send}/>
+      }
+    </>
+  );
+}
+
+CommentsList.propTypes = {
+  parent: PropTypes.shape({
+    _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    _type: PropTypes.string
+  }).isRequired,
+  count: PropTypes.number,
+  items: PropTypes.arrayOf(PropTypes.shape({
+    _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    author: PropTypes.shape({
+      _id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      profile: PropTypes.shape({name: PropTypes.string})
+    }),
+    dateCreate: PropTypes.string,
+    text: PropTypes.string,
+    isDeleted: PropTypes.bool,
+  }))
+};
+
+CommentsList.defaultProps = {
+  count: 0,
+  items: []
+}
+
+export default memo(CommentsList);

--- a/src/containers/comments-list/index.js
+++ b/src/containers/comments-list/index.js
@@ -55,15 +55,13 @@ function CommentsList(props) {
   const renders = {
     item: useCallback(item => (
       <>
-        <ItemComment item={item} lang={lang} onAnswer={setParent}/>
+        <ItemComment item={item} lang={lang} labelAnswer={t('comments.answer')} onAnswer={setParent}/>
         { parent._id === item._id &&
             <CommentForm
               title={t('comments.newAnswer')}
               theme='embed'
               autoFocus={true}
-              placeholder={t('comments.text')}
-              labelSend={t('comments.send')}
-              labelCancel={t('comments.cancel')}
+              t={t}
               exists={session.exists}
               onCancel={cancelAnswer}
               isCancelable={true}
@@ -75,7 +73,7 @@ function CommentsList(props) {
               onSubmit={callbacks.send}/>
         }
       </>
-    ), [lang, parent, text]),
+    ), [lang, parent, text, session.exists]),
   };
 
   const items = treeToList(listToTree(select.items), (item, level) => (
@@ -88,8 +86,7 @@ function CommentsList(props) {
       { parent._id === props.parent._id &&
           <CommentForm
             title={t('comments.newComment')}
-            placeholder={t('comments.text')}
-            labelSend={t('comments.send')}
+            t={t}
             exists={session.exists}
             inviteUrl='/login/'
             text={text}

--- a/src/containers/locale-select/index.js
+++ b/src/containers/locale-select/index.js
@@ -1,12 +1,12 @@
-import {memo, useCallback, useMemo} from 'react';
-import useStore from '../../hooks/use-store';
-import useSelector from '../../hooks/use-selector';
+import {memo, useMemo} from 'react';
 import useTranslate from '../../hooks/use-translate';
 import Select from '../../components/select';
 
 function LocaleSelect() {
 
-  const {lang, setLang} = useTranslate();
+  const {lang, setLang} = useTranslate(state => ({
+    lang: state.lang
+  }));
 
   const options = {
     lang: useMemo(() => ([

--- a/src/containers/navigation/index.js
+++ b/src/containers/navigation/index.js
@@ -31,7 +31,7 @@ function Navigation() {
   }
 
   // Функция для локализации текстов
-  const {t} = useTranslate();
+  const {t} = useTranslate(state => ({lang: state.lang}));
 
   const options = {
     menu: useMemo(() => ([

--- a/src/containers/top-head/index.js
+++ b/src/containers/top-head/index.js
@@ -7,7 +7,7 @@ import useStore from '../../hooks/use-store';
 
 function TopHead() {
 
-  const {t} = useTranslate();
+  const {t} = useTranslate(state => ({lang: state.lang}));
   const navigate = useNavigate();
   const location = useLocation();
   const store = useStore();

--- a/src/hooks/use-translate.js
+++ b/src/hooks/use-translate.js
@@ -1,9 +1,99 @@
-import {useCallback, useContext} from 'react';
-import {I18nContext} from '../i18n/context';
+import { useEffect, useMemo, useState } from 'react';
+import useServices from './use-services';
+import shallowequal from 'shallowequal';
 
 /**
- * Хук возвращает функцию для локализации текстов, код языка и функцию его смены
+ * Хук для выборки локали и отслеживания её изменения
+ * @param selectorFunc {Function}
+ * @return {*}
  */
+export default function useTranslate(selectorFunc) {
+  const i18n = useServices().i18n;
+
+  const [state, setState] = useState(() => selectorFunc(i18n.getState()));
+
+  const unsubscribe = useMemo(() => {
+    // Подписка. Возврат функции для отписки
+    return i18n.subscribe(() => {
+      const newState = selectorFunc(i18n.getState());
+      setState(prevState => shallowequal(prevState, newState) ? prevState : newState);
+    });
+  }, []); // Нет зависимостей - исполнится один раз
+
+  // Отписка при демонтировании компонента
+  useEffect(() => unsubscribe, [unsubscribe]);
+
+  return {
+    lang: state.lang,
+    t: i18n.translate.bind(i18n),
+    setLang: i18n.setLang.bind(i18n)
+  };
+}
+
+
+
+
+/**
+ * Хук возвращает объкат для локализации текстов
+ */
+export function useTranslate1() {
+  return useServices().i18n;
+
+  const i18n = useServices().i18n;
+
+  const [lang, setLang] = useState(i18n.lang);
+
+  return {
+    lang,
+    setLang: value => { setLang(value); i18n.setLang(value); },
+    toggle: () => { const l = i18n.lang === 'ru' ? 'en' : 'ru'; setLang(l); i18n.setLang(l); },
+    t: (text, plural, lang) => i18n.translate(text, plural, lang)
+  };
+
+  /*
+  return useMemo(
+    () => ({
+      lang,
+      setLang: value => { setLang(value); i18n.setLang(value); },
+      t: (text, plural, lang) => i18n.translate(text, plural, lang)
+    }),
+    [lang]
+  );
+  */
+
+  const t = useMemo(
+    () => {
+      return (text, plural, lang) => i18n.translate(text, plural, lang);
+    },
+    [lang]
+  );
+
+  return {
+    lang,
+    setLang: value => { setLang(value); i18n.setLang(value); },
+    t
+  }
+
+  /*
+  return {
+    lang: useServices().i18n.lang,
+    setLang: useServices().i18n.setLang,
+    t: useServices().i18n.translate
+  }
+  */
+
+  /*
+  return {
+    lang: useServices().i18n.lang,
+    setLang: value => {}, //useServices().i18n.lang(value),
+    t: (text, number, lang) => useServices().i18n.translate(text, number, lang)
+  }*/
+}
+
+/*
+import {useCallback, useContext} from 'react';
+import {I18nContext} from '../i18n/context';
 export default function useTranslate() {
   return useContext(I18nContext);
 }
+*/

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,80 @@
+import * as translations from './translations';
+
+class I18nService {
+  /**
+   * @param services {Services} Менеджер сервисов
+   * @param config {Object}
+   */
+  constructor(services, config = {}) {
+    this.services = services;
+    this._lang = localStorage.getItem('lang') || 'config.lang' || 'ru';
+    this.listeners = [];
+  }
+
+  /**
+   * Выбор состояния
+   * @returns {{
+   * lang: String,
+   * }}
+   */
+  getState() {
+    return {
+      lang: this._lang
+    };
+  }
+
+  /**
+   * Установка локали
+   * @param lang {String} Код языка
+   */
+  setLang(value) {
+    this._lang = value;
+    for (const listener of this.listeners) listener(this.getState());
+    window.localStorage.setItem('lang', value);
+  }
+
+  /**
+   * Возвращает локаль
+   * @returns {String} Код локали
+   */
+  get lang() {
+    return this._lang;
+  }
+
+  /**
+   * Перевод фразы по словарю
+   * @param lang {String} Код языка
+   * @param text {String} Текст для перевода
+   * @param [plural] {Number} Число для плюрализации
+   * @returns {String} Переведенный текст
+   */
+  translate(text, plural, lang = this._lang) {
+    let result = translations[lang] && (text in translations[lang])
+      ? translations[lang][text]
+      : text;
+
+    if (typeof plural !== 'undefined') {
+      const key = new Intl.PluralRules(lang).select(plural);
+      if (key in result) {
+        result = result[key];
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Подписка слушателя на изменения состояния
+   * @param listener {Function}
+   * @returns {Function} Функция отписки
+   */
+  subscribe(listener) {
+    this.listeners.push(listener);
+    // Возвращается функция для удаления добавленного слушателя
+    return () => {
+      this.listeners = this.listeners.filter(item => item !== listener);
+    }
+  }
+}
+
+export default I18nService;

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -7,8 +7,10 @@ class I18nService {
    */
   constructor(services, config = {}) {
     this.services = services;
+    this.config = config;
     this._lang = localStorage.getItem('lang') || 'config.lang' || 'ru';
     this.listeners = [];
+    this.services.api.setHeader(this.config.langHeader, this._lang);
   }
 
   /**
@@ -31,6 +33,8 @@ class I18nService {
     this._lang = value;
     for (const listener of this.listeners) listener(this.getState());
     window.localStorage.setItem('lang', value);
+    this.services.api.setHeader(this.config.langHeader, value);
+    location.reload();
   }
 
   /**

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -20,5 +20,12 @@
   "auth.password": "Password",
   "auth.signIn": "Sign in",
   "session.signIn": "Sign In",
-  "session.signOut": "Sign Out"
+  "session.signOut": "Sign Out",
+  "comments": "Comments",
+  "comments.newComment": "New comment",
+  "comments.newAnswer": "New answer",
+  "comments.answer": "Answer",
+  "comments.text": "Text",
+  "comments.send": "Send",
+  "comments.cancel": "Cancel"
 }

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -27,5 +27,7 @@
   "comments.answer": "Answer",
   "comments.text": "Text",
   "comments.send": "Send",
-  "comments.cancel": "Cancel"
+  "comments.cancel": "Cancel",
+  "comments.inviteAnchor": "Sign in",
+  "comments.invite": "Sign in to post comments"
 }

--- a/src/i18n/translations/ru.json
+++ b/src/i18n/translations/ru.json
@@ -22,5 +22,12 @@
   "auth.password": "Пароль",
   "auth.signIn": "Войти",
   "session.signIn": "Вход",
-  "session.signOut": "Выход"
+  "session.signOut": "Выход",
+  "comments": "Комментарии",
+  "comments.newComment": "Новый комментарий",
+  "comments.newAnswer": "Новый ответ",
+  "comments.answer": "Ответить",
+  "comments.text": "Текст",
+  "comments.send": "Отправить",
+  "comments.cancel": "Отмена"
 }

--- a/src/i18n/translations/ru.json
+++ b/src/i18n/translations/ru.json
@@ -29,5 +29,7 @@
   "comments.answer": "Ответить",
   "comments.text": "Текст",
   "comments.send": "Отправить",
-  "comments.cancel": "Отмена"
+  "comments.cancel": "Отмена",
+  "comments.inviteAnchor": "Войдите",
+  "comments.invite": "Войдите, чтобы иметь возможность комментировать"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import {createRoot} from 'react-dom/client';
 import {BrowserRouter} from 'react-router-dom';
 import {Provider} from 'react-redux';
 import {ServicesContext} from './context';
-import {I18nProvider} from './i18n/context';
 import App from './app';
 import Services from './services';
 import config from './config';
@@ -15,11 +14,9 @@ const root = createRoot(document.getElementById('root'));
 root.render(
   <Provider store={services.redux}>
     <ServicesContext.Provider value={services}>
-      <I18nProvider>
-        <BrowserRouter>
-          <App/>
-        </BrowserRouter>
-      </I18nProvider>
+      <BrowserRouter>
+        <App/>
+      </BrowserRouter>
     </ServicesContext.Provider>
   </Provider>
 );

--- a/src/services.js
+++ b/src/services.js
@@ -1,4 +1,5 @@
 import APIService from './api';
+import I18nService from './i18n';
 import Store from './store';
 import createStoreRedux from './store-redux';
 
@@ -38,6 +39,16 @@ class Services {
       this._redux = createStoreRedux(this, this.config.redux);
     }
     return this._redux;
+  }
+
+  /**
+   * Сервис i18n
+   */
+  get i18n() {
+    if (!this._i18n) {
+      this._i18n = new I18nService(this, this.config.i18n);
+    }
+    return this._i18n;
   }
 }
 

--- a/src/store-redux/comments/actions.js
+++ b/src/store-redux/comments/actions.js
@@ -13,12 +13,23 @@ export default {
         const res = await services.api.request({
           url: `/api/v1/comments?fields=items(_id,text,dateCreate,author(profile(name)),parent(_id,_type),isDeleted),count&limit=*&search[parent]=${parent}`
         });
-        // Комментарии загружены успешно
-        dispatch({type: 'comments/load-success', payload: {count: res.data.result.count, items: res.data.result.items}});
+
+        if (!res.data.error) {
+          // Комментарии загружены успешно
+          dispatch({type: 'comments/load-success', payload: {count: res.data.result.count, items: res.data.result.items}});
+        } else {
+          dispatch({
+            type: 'comments/send-error',
+            payload: { message: res.data.error }
+          });
+        }
 
       } catch (e) {
         //Ошибка загрузки
-        dispatch({type: 'comments/load-error'});
+        dispatch({
+          type: 'comments/send-error',
+          payload: { message: "Не удалось загрузить комментарии" }
+        });
       }
     }
   },
@@ -41,19 +52,29 @@ export default {
           body: JSON.stringify({parent, text})
         });
 
-        // Комментарий отправлен успешно
-        dispatch({
-          type: 'comments/send-success',
-          payload: {
-            comment: {
-              ...res.data.result,
-              author: {...res.data.result.author, profile: {name: user.profile.name}}
+        if (!res.data.error) {
+          // Комментарий отправлен успешно
+          dispatch({
+            type: 'comments/send-success',
+            payload: {
+              comment: {
+                ...res.data.result,
+                author: {...res.data.result.author, profile: {name: user.profile.name}}
+              }
             }
-          }
-        });
+          });
+        } else {
+          dispatch({
+            type: 'comments/send-error',
+            payload: { message: res.data.error }
+          });
+        }
       } catch (e) {
         //Ошибка отправки
-        dispatch({type: 'comments/send-error'});
+        dispatch({
+          type: 'comments/send-error',
+          payload: { message: "Не удалось отправить комментарий" }
+        });
       }
     }
   },

--- a/src/store-redux/comments/actions.js
+++ b/src/store-redux/comments/actions.js
@@ -1,0 +1,60 @@
+export default {
+  /**
+   * Загрузка комментариев
+   * @param parent
+   * @return {Function}
+   */
+  load: (parent) => {
+    return async (dispatch, getState, services) => {
+      // Сброс текущих комментариев и установка признака ожидания загрузки
+      dispatch({type: 'comments/load-start'});
+
+      try {
+        const res = await services.api.request({
+          url: `/api/v1/comments?fields=items(_id,text,dateCreate,author(profile(name)),parent(_id,_type),isDeleted),count&limit=*&search[parent]=${parent}`
+        });
+        // Комментарии загружены успешно
+        dispatch({type: 'comments/load-success', payload: {count: res.data.result.count, items: res.data.result.items}});
+
+      } catch (e) {
+        //Ошибка загрузки
+        dispatch({type: 'comments/load-error'});
+      }
+    }
+  },
+
+  /**
+   * Отправка комментария
+   * @param parent
+   * @param text
+   * @return {Function}
+   */
+  send: (user, parent, text) => {
+    return async (dispatch, getState, services) => {
+      // Установка признака ожидания отправки
+      dispatch({type: 'comments/send-start'});
+
+      try {
+        const res = await services.api.request({
+          url: '/api/v1/comments',
+          method: 'POST',
+          body: JSON.stringify({parent, text})
+        });
+
+        // Комментарий отправлен успешно
+        dispatch({
+          type: 'comments/send-success',
+          payload: {
+            comment: {
+              ...res.data.result,
+              author: {...res.data.result.author, profile: {name: user.profile.name}}
+            }
+          }
+        });
+      } catch (e) {
+        //Ошибка отправки
+        dispatch({type: 'comments/send-error'});
+      }
+    }
+  },
+}

--- a/src/store-redux/comments/reducer.js
+++ b/src/store-redux/comments/reducer.js
@@ -4,28 +4,29 @@ export const initialState = {
   items: [],
   waiting: false, // признак ожидания загрузки
   sending: false, // признак ожидания отправки
+  message: ''
 }
 
 // Обработчик действий
 function reducer(state = initialState, action) {
   switch (action.type) {
     case "comments/load-start":
-      return {...state, count: 0, items: [], waiting: true};
+      return {...state, message: '', count: 0, items: [], waiting: true};
 
     case "comments/load-success":
       return {...state, count: action.payload.count, items: action.payload.items, waiting: false};
 
     case "comments/load-error":
-      return {...state, count: 0, items: [], waiting: false}; //@todo текст ошибки сохранять?
+      return {...state, message: action.payload.message, count: 0, items: [], waiting: false};
 
     case "comments/send-start":
-      return {...state, sending: true};
+      return {...state, message: '', sending: true};
 
     case "comments/send-success":
       return {...state, count: state.count + 1, items: [...state.items, action.payload.comment], sending: false};
       
     case "comments/send-error":
-      return {...state, sending: false}; //@todo текст ошибки сохранять?
+      return {...state, message: action.payload.message, sending: false};
 
     default:
       // Нет изменений

--- a/src/store-redux/comments/reducer.js
+++ b/src/store-redux/comments/reducer.js
@@ -1,0 +1,36 @@
+// Начальное состояние
+export const initialState = {
+  count: 0,
+  items: [],
+  waiting: false, // признак ожидания загрузки
+  sending: false, // признак ожидания отправки
+}
+
+// Обработчик действий
+function reducer(state = initialState, action) {
+  switch (action.type) {
+    case "comments/load-start":
+      return {...state, count: 0, items: [], waiting: true};
+
+    case "comments/load-success":
+      return {...state, count: action.payload.count, items: action.payload.items, waiting: false};
+
+    case "comments/load-error":
+      return {...state, count: 0, items: [], waiting: false}; //@todo текст ошибки сохранять?
+
+    case "comments/send-start":
+      return {...state, sending: true};
+
+    case "comments/send-success":
+      return {...state, count: state.count + 1, items: [...state.items, action.payload.comment], sending: false};
+      
+    case "comments/send-error":
+      return {...state, sending: false}; //@todo текст ошибки сохранять?
+
+    default:
+      // Нет изменений
+      return state;
+  }
+}
+
+export default reducer;

--- a/src/store-redux/exports.js
+++ b/src/store-redux/exports.js
@@ -1,2 +1,3 @@
 export {default as article} from './article/reducer';
 export {default as modals} from './modals/reducer';
+export {default as comments} from './comments/reducer';

--- a/src/utils/date-format.js
+++ b/src/utils/date-format.js
@@ -1,0 +1,10 @@
+/**
+ * Форматирование даты
+ * @param value {String}
+ * @param options {Object}
+ * @returns {String}
+ */
+export default function dateFormat(value, locale = 'ru-RU', options = {}) {
+  const date = new Date(value);
+  return new Intl.DateTimeFormat(locale, options).format(date);
+}


### PR DESCRIPTION
В новом пул-реквесте:

1. Добавил возможность оставлять комментарии для авторизованных пользователей. Комментарии работают через состояние redux. Полученный список преобразуется в дерево использованием уже готовых утилит listToTree и treeToList. Ввод текста в "глупой" компоненте CommentForm контролируется из "умного" контейнера CommentsList. Это нужно чтобы сбросить текст комментария после успешной отправки.

2. Добавил сервис I18n. У сервиса есть состояние, в котором хранится код выбранного языка. Модифицировал хук useTranslate. Рендер компонентов после смены языка происходит через подписку на изменения в состоянии. После смены языка сервис I18n устанавливает заголовок X-Lang в сервисе API. Это решение для меня проще, т.к. не нужно подписывать API на смену локали. Кроме того, это решение "чище", поскольку у API остаётся только одна ответственность: отправлять запросы к бэкенду.